### PR TITLE
Updating parser to allow dollar-sign to be escaped using a sequence o…

### DIFF
--- a/executables/APITests.hs
+++ b/executables/APITests.hs
@@ -10,10 +10,10 @@ main = htfMain $ htf_thisModulesTests
 
 test_demo = do
   assertEqual
-    "function(){\n  function(){\n    {\n      indented line\n      indented line\n    }\n  }\n  return {\n    indented line\n    indented line\n  }\n}\n"
+    "function(){\n  function(){\n    {\n      indented line\n      indented line\n    }\n  }\n  return \"$b\"\n}\n"
     (template a a)
   assertEqual
-    "this_could_be_one_long_identifier\n"
+    "this_could_be_$one$_long_identifier\n"
     (escaped "one")
   where
     template a b = 
@@ -22,9 +22,9 @@ test_demo = do
           function(){
             $a
           }
-          return $b
+          return "$$b"
         }
       |]
-    escaped name = [text|this_could_be_${name}_long_identifier|]
+    escaped name = [text|this_could_be_$$${name}$$_long_identifier|]
     a = "{\n  indented line\n  indented line\n}"
 


### PR DESCRIPTION
I'm not really familiar with parsec, so I don't think it's the best way, but I think it's a pretty simple solution. I'm proposing an escape sequence of two consecutive dollar-signs. The parser is simple enough, if we find a `$`, try to consume another `$`, otherwise try to get an identifier. Example:

    query :: Text -> Text
    query fields = [text| SELECT $fields FROM foobar WHERE id=$$1 ]
    
Calling `query "id, name"` should output `SELECT id, name FROM foobar WHERE id=$1`. It should also work on silly strings like `$$$a$$$b$$${a_long_identifier}$$`.