### PR TITLE
Fixed typo in neat-interpolation.cabal

### DIFF
--- a/neat-interpolation.cabal
+++ b/neat-interpolation.cabal
@@ -10,7 +10,7 @@ description:
   It removes the excessive indentation from the input and 
   accurately manages the indentation of all lines of the interpolated variables. 
 category:
-  String, QuasiQoutes
+  String, QuasiQuotes
 license:
   MIT
 license-file:


### PR DESCRIPTION
Hackage category renamed from `QuasiQoutes` to `QuasiQuotes`.