### PR TITLE
Generalize to `IsString a => a`

### DIFF
--- a/library/NeatInterpolation.hs
+++ b/library/NeatInterpolation.hs
@@ -123,8 +123,8 @@ quoteExp :: String -> Q Exp
 quoteExp input =
   case Parsing.parseLines input of
     Left e -> fail $ show e
-    Right lines -> sigE (appE [|Text.intercalate (Text.singleton '\n')|] $ listE $ map lineExp lines)
-                        [t|Text|]
+    Right lines -> sigE (appE [|fromString . Text.unpack . Text.intercalate (Text.singleton '\n')|] $ listE $ map lineExp lines)
+                        [t|forall a. IsString a => a|]
 
 lineExp :: Parsing.Line -> Q Exp
 lineExp (Parsing.Line indent contents) =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -7,9 +7,12 @@ import Test.Tasty.Runners
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
 import NeatInterpolation
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString as BS
 import qualified Test.QuickCheck as QuickCheck
 import qualified Test.QuickCheck.Property as QuickCheck
-
 
 main = defaultMain $ testGroup "" $
   [
@@ -63,4 +66,12 @@ main = defaultMain $ testGroup "" $
       in assertEqual ""
           "* @param a value of the {@code a} property of\n         the {@code b} case"
           (template "a" "b")
+    ,
+    testGroup "Polymorphism"
+      [ testCase "String"          $ assertEqual "" [trimming|foo|] ("foo" :: String)
+      , testCase "Text"            $ assertEqual "" [trimming|foo|] ("foo" :: T.Text)
+      , testCase "Lazy Text"       $ assertEqual "" [trimming|foo|] ("foo" :: TL.Text)
+      , testCase "ByteString"      $ assertEqual "" [trimming|foo|] ("foo" :: BS.ByteString)
+      , testCase "Lazy ByteString" $ assertEqual "" [trimming|foo|] ("foo" :: BL.ByteString)
+      ]
   ]


### PR DESCRIPTION
This is one way to address #17, it simply generalizes the resulting value to `IsString a => a`. This is mostly an experiment to see if it was possible, and it seems to work out nicely, but maybe you have a good reason for not wanting to use `IsString`. Either way, please let me know.

If you do think this is a good idea, there's probably some cleanup to do before merging, like removing dependencies and/or not using `String` as the intermediate representation.